### PR TITLE
buildFields: allow null values

### DIFF
--- a/src/JournalHandler.php
+++ b/src/JournalHandler.php
@@ -147,7 +147,7 @@ class JournalHandler extends AbstractProcessingHandler
      * @param bool|int|float|string|Stringable $value
      * @return string
      */
-    protected function buildField(string|JournalFields $field, bool|int|float|string|Stringable $value): string
+    protected function buildField(string|JournalFields $field, bool|int|float|string|Stringable|null $value): string
     {
         if ($field instanceof JournalFields) {
             $field = $field->value;


### PR DESCRIPTION
Somehow we've managed to sneak a null value in, which breaks the JournalHandler.